### PR TITLE
Update countryMatch for Canada - remove improper 'ca' designation/match

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -124,7 +124,6 @@
             "symbol": "🇨🇦",
             "countryMatch": [
                 "canada",
-                "ca",
                 "can",
                 "canadian",
                 "toronto",


### PR DESCRIPTION
Removed 'ca' from countryMatch for Canada.

This was improperly asserting California users who didn't provide country as Canadian